### PR TITLE
Modify svg helper so it references path correctly in preview and build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 /build/
 /node_modules/
 /public/

--- a/src/helpers/svg.js
+++ b/src/helpers/svg.js
@@ -1,10 +1,9 @@
 'use strict'
 
-const fs = require('fs')
 const path = require('path')
 
-module.exports = (iconName) => {
-  const pathName = path.join(__dirname, '/src/img/', iconName + '.svg')
-  const content = fs.readFileSync(pathName, 'utf8')
-  return content
+module.exports = (iconName, { data }) => {
+  const uiRootPath = data.root.uiRootPath
+  const svgFilePath = path.join(uiRootPath, 'img', iconName + '.svg')
+  return '<img src="' + svgFilePath + '" alt="' + iconName + '" />'
 }


### PR DESCRIPTION
This updates the svg handlerbars helper so the svg is rendered with an `img` tag rather than attempting to read the content of the svg file and return that to the rendered page.

The reason this is necessary is because at build time, the path to the UI bundle isn't the same as when running a UI preview build.  By using an image tag we can simply refer to the `uiRootPath` so the image knows where to look when the page is compiled to its static HTML

To test:

1. Pull down and checkout this branch
2. Run `gulp bundle`
3. In the datastax docs site repo, refer to the UI bundle path given with the output of the above command
4. run `npm run build:develop` for the datastax docs site
5. Navigate to the tutorial template and see that the collab svg is rendering for the Run this on Colab button

![image](https://github.com/riptano/docs-ui/assets/344177/3432b995-956e-4e45-a137-4de9b81ba646)
