### PR TITLE
Add Tailwind

### DIFF
--- a/gulp.d/tasks/build.js
+++ b/gulp.d/tasks/build.js
@@ -78,6 +78,7 @@ module.exports = (src, dest, preview) => () => {
       .pipe(map((file, enc, next) => next(null, Object.assign(file, { extname: '' }, { extname: '.js' })))),
     // NOTE use the next line to bundle a JavaScript library that cannot be browserified, like jQuery
     //vfs.src(require.resolve('<package-name-or-require-path>'), opts).pipe(concat('js/vendor/<library-name>.js')),
+    vfs.src('./tailwind.config.js').pipe(concat('js/tailwind.config.js')),
     vfs
       .src(['css/site.css', 'css/vendor/*.css'], { ...opts, sourcemaps })
       .pipe(postcss((file) => ({ plugins: postcssPlugins, options: { file } }))),

--- a/preview-src/astra.adoc
+++ b/preview-src/astra.adoc
@@ -1,37 +1,51 @@
-= {company} Astra
+= DataStax Astra
 :page-layout: full
-:vector-image: image::ROOT:ui/integrations-browser.png[Browser,420,220,align=center]
 
+[.max-w-[650px]]
 DataStax Astra is a cutting-edge cloud-native database platform designed to empower developers.
 Harnessing the strengths of vector databases, serverless computing, and real-time streaming, Astra propels application development into the next generation.
 From AI-driven capabilities to robust data stream management, Astra simplifies complex tasks, offering unparalleled performance and scalability.
 
-[.ds-feature-buttons]
-https://astra.datastax.com[Explore Astra Vector^,role="ds-button ds-button\--color-primary ds-button\--variant-solid"]
-https://astra.datastax.com[Create Astra Account^,role="ds-button ds-button\--color-primary ds-button\--variant-outlined external"]
+[.[&>h2]:hidden]
+== {empty}
 
-[.vector.header-noline.text-h1.row.border-bottom]
-== Vector
---
-[.landing-card-icon]
-image:astra-vector.svg[vector,20,role=for-light]
-image:astra-vector-dark.svg[vector,20,role=for-dark]
+++++
+<div class="flex rounded-[6px] bg-[var(--ds-neutral-soft-bg)] p-3 -mx-3">
+<div class="flex flex-col lg:basis-2/4">
+++++
+
+[discrete.[&>h2]:border-0.!m-0]
+== image:astra-vector.svg[vector,20,role="for-light landing-card-icon block mb-1"] image:astra-vector-dark.svg[vector,20,role="for-dark landing-card-icon block mb-1"] Vector
 
 Delve into a database optimized for AI-driven tasks.
 Astra Vector is tailored to offer unparalleled precision, speed, and scalability for AI applications, transforming how your applications perceive and interact with data.
 
-[.landing-a]
-xref:astra-vector::index.adoc[Learn More About Astra Vector]
---
-image::astra-browser.png[Browser,420,220,align=center,float=bottom]
+++++
+<div class="flex flex-nowrap gap-1">
+++++
 
-''''
+https://astra.datastax.com[Explore Astra Vector^,role="ds-button ds-button\--color-primary ds-button\--variant-solid"]
 
-[.grid]
---
-[discrete]
-=== Serverless C*
+https://astra.datastax.com[Create Astra Account^,role="ds-button ds-button\--color-primary ds-button\--variant-outlined external"]
 
+++++
+</div>
+</div>
+<div class="hidden lg:block flex basis-2/4 relative">
+++++
+
+[.absolute.-bottom-3.right-0]
+image::astra-browser.png[Browser,550,348,align=center,float=top]
+
+++++
+</div>
+</div>
+<div class="flex flex-col md:flex-row gap-3">
+<div class="flex-col">
+++++
+
+[discrete.m-0]
+=== [.material-icons.landing-card-icon.block.mb-1]#table_chart# Serverless C*
 Delve deep into high-dimensional spaces with Astra Vector.
 Engineered for AI-intensive tasks, it offers unparalleled precision, speed, and scalability.
 Bring complex AI models into production with confidence, leveraging Astra's robust architecture.
@@ -39,15 +53,13 @@ Bring complex AI models into production with confidence, leveraging Astra's robu
 [.landing-a]
 https://docs.datastax.com/en/astra-serverless/docs/index.html[Discover Astra Serverless C*]
 
-[.material-icons.landing-card-icon]
-table_chart
+++++
+</div>
+<div class="flex-col">
+++++
 
---
-
-[.grid]
---
 [discrete]
-=== Streaming
+=== [.material-icons.landing-card-icon.block.mb-1]#air# Streaming
 
 Harness real-time data with Astra Streaming.
 Process, analyze, and act on data as it's generated.
@@ -56,14 +68,17 @@ Whether you're analyzing user behavior or monitoring systems, Astra Streaming de
 [.landing-a]
 https://docs.datastax.com/en/streaming/astra-streaming/index.html[Dive into Astra Streaming]
 
-[.material-icons.landing-card-icon]
-air
+++++
+</div>
+</div>
+++++
 
---
-
-
-[.header-noline.text-h1.ds-row.ds-grid]
+[.text-h1.[&>h2]:!border-0]
 == Explore More of Astra
+
+++++
+<div class="flex flex-col lg:flex-row gap-3 mb-5">
+++++
 
 === Dive Deeper into Vector
 
@@ -91,3 +106,7 @@ Delve deeper into the real-time data processing capabilities of Astra.
 * link:{#}[Streaming Fundamentals]
 * link:{#}[Advanced Streaming Configurations]
 * link:{#}[Starlight Integrations: JMS, Kafka, RabbitMQ]
+
+++++
+</div>
+++++

--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -992,13 +992,13 @@ image::screenshot.png[Screenshot of Astra Portal Home]
 image::screenshot.png[Screenshot of Astra Portal Home,300]
 
 .SVG image (300px width; default alignment). Image is rasterized (`opts=` _none_).
-image::multirepo-ssg.svg[Multirepo SSG,300]
+image::preview-src/multirepo-ssg.svg[Multirepo SSG,300]
 
 .SVG image (300px width; default alignment). Image embedded as a live, interactive object (`opts=interactive`).
-image::multirepo-ssg.svg[Multirepo SSG,300,opts=interactive]
+image::preview-src/multirepo-ssg.svg[Multirepo SSG,300,opts=interactive]
 
 .SVG image (300px width; default alignment). Image embedded directly into the HTML itself (`opts=inline`).
-image::multirepo-ssg.svg[Multirepo SSG,300,opts=inline]
+image::preview-src/multirepo-ssg.svg[Multirepo SSG,300,opts=inline]
 
 ==== Aligning block images
 

--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -5,6 +5,7 @@ asciidoc:
 site:
   url: http://localhost:5252
   title: Brand Docs
+  isPreviewSite: true
   homeUrl: &home_url /xyz/5.2/index.html
   components:
   - name: abc

--- a/src/css/print.css
+++ b/src/css/print.css
@@ -68,7 +68,8 @@
   }
 
   .doc .admonitionblock td.icon {
-    color-adjust: exact;
+    /* stylelint-disable-next-line property-no-unknown */
+    print-color-adjust: exact;
   }
 
   .doc .listingblock code[data-lang]::before {

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -27,4 +27,5 @@
 @import "highlight.css";
 @import "print.css";
 @import "tutorial-info.css";
-@import "docsearch.css"
+@import "docsearch.css";
+@import "tailwind.css"

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -1,0 +1,4 @@
+/* stylelint-disable at-rule-no-unknown */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/js/01-nav.js
+++ b/src/js/01-nav.js
@@ -4,6 +4,9 @@
   var SECT_CLASS_RX = /^sect(\d)$/
 
   var navContainer = document.querySelector('.nav-container')
+
+  if (!navContainer) return
+
   var navToggle = document.querySelector('.nav-toggle')
   var nav = navContainer.querySelector('.nav')
 

--- a/src/partials/head-styles.hbs
+++ b/src/partials/head-styles.hbs
@@ -1,8 +1,5 @@
 <link rel="stylesheet" href="{{{uiRootPath}}}/css/site.css">
 <link rel="stylesheet" href="{{{uiRootPath}}}/css/vendor/tabs.css">
-{{#unless site.isPreviewSite}}
-<link rel="stylesheet" href="{{{uiRootPath}}}/css/tailwind.css">
-{{/unless}}
 {{#if site.isPreviewSite}}
 <script src="https://cdn.tailwindcss.com"></script>
 <script type="module">

--- a/src/partials/head-styles.hbs
+++ b/src/partials/head-styles.hbs
@@ -1,2 +1,12 @@
-    <link rel="stylesheet" href="{{{uiRootPath}}}/css/site.css">
-    <link rel="stylesheet" href="{{{uiRootPath}}}/css/vendor/tabs.css">
+<link rel="stylesheet" href="{{{uiRootPath}}}/css/site.css">
+<link rel="stylesheet" href="{{{uiRootPath}}}/css/vendor/tabs.css">
+{{#unless site.isPreviewSite}}
+<link rel="stylesheet" href="{{{uiRootPath}}}/css/tailwind.css">
+{{/unless}}
+{{#if site.isPreviewSite}}
+<script src="https://cdn.tailwindcss.com"></script>
+<script type="module">
+    import tailwindconfig from '/{{{uiRootPath}}}/js/tailwind.config.js'
+    tailwind.config = tailwindconfig
+</script>
+{{/if}}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,32 @@
+const tailwindconfig = {
+  content: ['./build/site/**/*.{html,js}'],
+  theme: {
+    spacing: {
+      0: '0',
+      0.5: '0.5rem',
+      1: '1rem',
+      1.5: '1.5rem',
+      2: '2rem',
+      2.5: '2.5rem',
+      3: '3rem',
+      3.5: '3.5rem',
+      4: '4rem',
+      5: '5rem',
+      6: '6rem',
+      7: '7rem',
+      8: '8rem',
+      9: '9rem',
+      10: '10rem',
+      11: '11rem',
+      15: '15rem',
+    },
+    extend: {
+      spacing: {
+        0.25: '0.25rem',
+      },
+    },
+  },
+  plugins: [],
+}
+
+export default tailwindconfig


### PR DESCRIPTION
This work adds some tailwind css and a config file. The config file is included in the UI bundle.

On the antora site just after building we can run this script to bake all the tailwind css into site.css
```
tailwindcss build -c ./build/site/_/js/tailwind.config.js -i ./build/site/_/css/site.css -o ./build/site/_/css/site.css --minify
```

This way the tailwind config and tailwind css additions live in the UI bundle repo, and are passed to the site repo to be used once all the html is generated