### PR TITLE
Add integrations overview layout

### DIFF
--- a/preview-src/page-templates/integrations-overview.adoc
+++ b/preview-src/page-templates/integrations-overview.adoc
@@ -1,5 +1,5 @@
 = Integrations
-:page-layout: tutorial
+:page-layout: overview
 :hugging-icon: image:../img/hugging-face.svg[,20]
 :langchain-icon: image:../img/langchain.svg[,20]
 :openai-icon: image:../img/openai.svg[,20]

--- a/src/css/ds-card.css
+++ b/src/css/ds-card.css
@@ -27,8 +27,8 @@
 }
 
 .ds-card .paragraph.landing-card-icon,
+.doc .ds-card .tags-container,
 .ds-card > .title {
-  margin-top: 0;
   margin-bottom: var(--ds-space-3);
 }
 

--- a/src/layouts/overview.hbs
+++ b/src/layouts/overview.hbs
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en" data-layout="overview">
+  <head>
+{{> head defaultPageTitle='Untitled'}}
+  </head>
+  <body class="article{{#with (or page.attributes.role page.role)}} {{{this}}}{{/with}}">
+{{> header}}
+{{> body}}
+  </body>
+</html>

--- a/src/partials/main.hbs
+++ b/src/partials/main.hbs
@@ -6,7 +6,9 @@
     {{#if (eq page.layout '404')}}
     {{> article-404}}
     {{else}}
-    {{#unless (or (eq page.layout 'full') (eq page.layout 'landing'))}}
+    {{#unless (or (eq page.layout 'full')
+                  (eq page.layout 'landing')
+                  (eq page.layout 'overview'))}}
     {{> toc}}
     {{/unless}}
     {{> article}}

--- a/src/partials/support-feedback.hbs
+++ b/src/partials/support-feedback.hbs
@@ -32,10 +32,12 @@
     <div class="sect2 basis-1/2">
       <h3>Need More Help?</h3>
       <div class="mt-2 flex flex-col gap-2">
-        <a href="https://www.datastax.com/dev/community" target="_blank">
+        <a href="https://www.datastax.com/dev/community"
+          class="remove-ext-icon" target="_blank">
           <i class="material-icons mr-1">group</i>Ask the Astra community
         </a>
-        <a href="https://support.datastax.com/" target="_blank">
+        <a href="https://support.datastax.com/"
+          class="remove-ext-icon" target="_blank">
           <i class="material-icons mr-1">support</i>Get in touch with support
         </a>
       </div>


### PR DESCRIPTION
Add integrations overview layout
```
page-layout: overview
```

- Remove external icon from support feedback
- Fix integrations overview cards