### PR TITLE
Add workflow to automate new UI bundle releases

### DIFF
--- a/.github/workflows/release-ui-bundle.yml
+++ b/.github/workflows/release-ui-bundle.yml
@@ -1,0 +1,83 @@
+name: Release UI Bundle
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  bundle-release:
+     runs-on: ubuntu-latest
+
+     steps:
+       - name: Configure Git Credentials
+         uses: de-vri-es/setup-git-credentials@v2
+         with:
+           credentials: ${{ secrets.GIT_CREDENTIALS }}
+
+       - name: Checkout Repository
+         uses: actions/checkout@v4
+         with:
+           fetch-depth: 0 # fetch tags too
+
+       - name: Check Last Commit Message
+         id: skip_release
+         env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+         run: |
+           last_commit_message=$(git log -1 --pretty=%B)
+           if [[ $last_commit_message == *"[no-release]"* ]]; then
+             echo "Last commit message contains [no-release]. Skipping workflow."
+             echo "skip_release=1" >> $GITHUB_OUTPUT
+           fi
+
+       - name: Setup Node.js
+         if: ${{ steps.skip_release.outputs.skip_release == '' }}
+         uses: actions/setup-node@v4
+         with:
+           node-version: 21.6.1
+
+       - name: Install Dependencies
+         if: ${{ steps.skip_release.outputs.skip_release == '' }}
+         run: npm ci
+
+       - name: Build UI Bundle
+         if: ${{ steps.skip_release.outputs.skip_release == '' }}
+         run: |
+           set -o pipefail
+           gulp bundle |& tee $GITHUB_WORKSPACE/build.log
+
+       - name: Get Latest Release Tag
+         id: get_latest_tag
+         if: ${{ steps.skip_release.outputs.skip_release == '' }}
+         run: |
+           latest_tag=$(git describe --tags --abbrev=0)
+           echo "tag=$latest_tag" >> $GITHUB_OUTPUT
+
+       - name: Extract Tag Integer
+         id: extract_tag_integer
+         if: ${{ steps.skip_release.outputs.skip_release == '' }}
+         run: |
+           parsed_tag=${{ steps.get_latest_tag.outputs.tag }}
+           tag_integer=$(echo $parsed_tag | grep -oE '[0-9]+')
+           echo "tag_integer=$tag_integer" >> $GITHUB_OUTPUT
+
+       - name: Increment Tag
+         id: increment_tag
+         if: ${{ steps.skip_release.outputs.skip_release == '' }}
+         run: |
+           current_tag_integer=${{ steps.extract_tag_integer.outputs.tag_integer }}
+           next_tag_integer=$((current_tag_integer + 1))
+           next_tag="prod-$next_tag_integer"
+           echo "next_tag=$next_tag" >> $GITHUB_OUTPUT
+
+       - name: Create Release
+         if: ${{ steps.skip_release.outputs.skip_release == '' }}
+         env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+           tag: ${{ steps.increment_tag.outputs.next_tag }}
+         run: |
+           gh release create "$tag" build/ui-bundle.zip \
+               --repo="$GITHUB_REPOSITORY" \
+               --title=$tag \
+               --generate-notes


### PR DESCRIPTION
This PR adds a new workflow to automate new UI bundle releases

- Upon merge to main a new UI bundle will be built using `gulp bundle` (linting also occurs during this step)
- Assuming a successful build, we obtain the previous tag and increment it
- Successful bundle is then released as the next `prod-#` and release notes are auto generated
- Release can be skipped using `[no-release]` in the commit message