### PR TITLE
Update node version used for bundle preview workflow

### DIFF
--- a/.github/workflows/deploy-bundle-preview.yml
+++ b/.github/workflows/deploy-bundle-preview.yml
@@ -22,9 +22,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.20.2
+          node-version: 21.6.1
 
       - name: Install Dependencies
         run: npm ci


### PR DESCRIPTION
Node 16 is EOL.

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/