### PR TITLE
Update glossary link href

### DIFF
--- a/src/partials/nav-secondary.hbs
+++ b/src/partials/nav-secondary.hbs
@@ -12,7 +12,7 @@
   <li>
     <a
       class="text-body-small text-primary hover:bg-level2 flex rounded p-1 !no-underline transition-colors"
-      href="/en/glossary/doc"
+      href="/en/glossary"
       target="_blank"
     >
       <span class="material-icons text-tertiary mr-2">menu_book</span>


### PR DESCRIPTION
Currently `/glossary/doc` is redirected to `/glossary/docs` however, just dropping `/doc` altogether also works and better aligns with the unified build.