### PR TITLE
DOC-4344: Add Algolia site keys to playbooks

### DIFF
--- a/src/partials/body-end-scripts.hbs
+++ b/src/partials/body-end-scripts.hbs
@@ -4,13 +4,17 @@
 <script async src="{{{uiRootPath}}}/js/vendor/zooming.js"></script>
 
 <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
+{{#with site.keys}}
+  {{#if (and algoliaAppId algoliaIndexName algoliaApiKey)}}
 <script>
   docsearch({
     container: '#docsearch',
-    appId: '{{site.keys.algoliaAppId}}',
-    indexName: '{{site.keys.algoliaIndexName}}',
+    appId: '{{algoliaAppId}}',
+    indexName: '{{algoliaIndexName}}',
     {{!-- This is the public API key which can be safely used in frontend code. --}}
-    apiKey: '{{site.keys.algoliaApiKey}}',
+    apiKey: '{{algoliaApiKey}}',
   })
 </script>
+  {{/if}}
+{{/with}}
 {{> intercom}}

--- a/src/partials/body-end-scripts.hbs
+++ b/src/partials/body-end-scripts.hbs
@@ -7,10 +7,10 @@
 <script>
   docsearch({
     container: '#docsearch',
-    appId: '2ELPRZR9UC',
-    indexName: 'crawler_docsearch-astra',
+    appId: '{{site.keys.algoliaAppId}}',
+    indexName: '{{site.keys.algoliaIndexName}}',
     {{!-- This is the public API key which can be safely used in frontend code. --}}
-    apiKey: '1f4acbf51d118e4137e9a63b38bd8456',
+    apiKey: '{{site.keys.algoliaApiKey}}',
   })
 </script>
 {{> intercom}}


### PR DESCRIPTION
**Jira**: [DOC-4344](https://datastax.jira.com/browse/DOC-4344)

This PR updates the DocSearch script configuration to use variables instead of explicit hard-coded values. In this paradigm, the UI now depends on the playbook to supply the corresponding values (in this case using `site.keys`).

In addition, I've added conditional logic such that if any of the variables is missing or undefined in the playbook, then the script doesn't get generated (and the search box doesn't appear in the UI). I felt that this was more ideal than loading a non-functional search box if the values weren't supplied. If this isn't the desired behavior, then we might consider adding default values to the build logic so that we at least ensure that a valid configuration is supplied.

**IMPORTANT**: We must merge https://github.com/riptano/datastax-docs-site/pull/157  **_first_** before implementing the UI changes in this PR.

[DOC-4344]: https://datastax.jira.com/browse/DOC-4344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ