### PR TITLE
Use variables instead of explicit URLs

### DIFF
--- a/src/partials/article-404.hbs
+++ b/src/partials/article-404.hbs
@@ -1,15 +1,13 @@
 <article class="doc">
   <h1 class="page">{{{or page.title "Page Not Found"}}}</h1>
   <div class="paragraph">
-    <p>The page you&#8217;re looking for does not exist. It may have been moved.
-      You can{{#with site.homeUrl}}
-        return to the
-        <a href="{{{this}}}">start page</a>, or{{/with}}
-      follow one of the links in the navigation to the left.</p>
+    <p>The page you&#8217;re looking for doesn&#8217;t exist. It may have been moved. You can return to the
+      <a href="{{{site.path}}}{{{site.homeUrl}}}">start page</a>, or follow one of the links in the navigation above.
+    </p>
   </div>
   <div class="paragraph">
-    <p>If you arrived on this page by clicking on a link, please notify the
-      owner of the site that the link is broken. If you typed the URL of this
-      page manually, please double check that you entered the address correctly.</p>
+    <p>If you arrived on this page by clicking a link on another site, please notify the owner of that site that the
+      link is broken.
+      If you typed the URL of this page manually, please double check that you entered the address correctly.</p>
   </div>
 </article>

--- a/src/partials/head-meta.hbs
+++ b/src/partials/head-meta.hbs
@@ -12,7 +12,7 @@
     <meta property="og:url" content="{{page.canonicalUrl}}">
     <meta property="og:title" content="{{page.title}} :: {{site.title}}">
     <meta property="og:description" content="{{page.description}}">
-    <meta property="og:image" content="https://docs.datastax.com/en/astra/_/img/datastax-docs-banner.png">
+    <meta property="og:image" content="{{{site.url}}}{{{site.ui.url}}}/img/datastax-docs-banner.png">
     <meta property="og:image:type" content="image/png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="628">
@@ -24,18 +24,18 @@
     <meta name="twitter:url" content="{{page.canonicalUrl}}">
     <meta name="twitter:title" content="{{page.title}} :: {{site.title}}">
     <meta name="twitter:description" content="{{page.description}}">
-    <meta name="twitter:image" content="https://docs.datastax.com/en/astra/_/img/datastax-docs-banner.png">
+    <meta name="twitter:image" content="{{{site.url}}}{{{site.ui.url}}}/img/datastax-docs-banner.png">
     <script type="application/ld+json">
     [
     {{!-- {{commented expressions}} --}}
-    {{#if (eq  "https://docs.datastax.com/en/astra/home/astra.html" page.canonicalUrl)}}
+    {{#if (eq  "{{{site.url}}}{{{site.homeUrl}}}" page.canonicalUrl)}}
     {
         "@context": "https://schema.org",
         "@type": "WebSite",
         "@id": "https://docs.datastax.com",
         "name": "DataStax Documentation",
         "url": "{{page.canonicalUrl}}",
-        "image": "https://docs.datastax.com/en/astra/_/img/datastax-docs-banner.png",
+        "image": "{{{site.url}}}{{{site.ui.url}}}/img/datastax-docs-banner.png",
         "sameAs": [
              "https://github.com/datastaxdevs/",
              "https://twitter.com/datastaxdevs",
@@ -90,7 +90,7 @@
             "headline": "{{page.title}}",
             "description":"{{page.description}}",
             "keywords":"{{page.keywords}}",
-            "image": "https://docs.datastax.com/en/astra/_/img/datastax-docs-banner.png",
+            "image": "{{{site.url}}}{{{site.ui.url}}}/img/datastax-docs-banner.png",
             "publisher":{
                 "@type": "Corporation",
                 "@id": "https://datastax.com#organization",

--- a/src/partials/nav-secondary.hbs
+++ b/src/partials/nav-secondary.hbs
@@ -12,7 +12,7 @@
   <li>
     <a
       class="text-body-small text-primary hover:bg-level2 flex rounded p-1 !no-underline transition-colors"
-      href="/en/glossary"
+      href="{{{site.path}}}/glossary"
       target="_blank"
     >
       <span class="material-icons text-tertiary mr-2">menu_book</span>


### PR DESCRIPTION
This started out as @mlr and I's attempt to fix the homepage link on the 404 page. I then noticed a few URLs that could probably be made more durable using variables.

@colegoldsmith, Ronnie and I are pretty unfamiliar with variables and handlebars, but after a little testing we _think_ these are working as expected. I'm also pretty unfamiliar with the proper use of double and triple mustaches, and I don't know how all of these meta properties are supposed to work. Can you pick up where we left off? 