### PR TITLE
Use node global context to get assetManifest

### DIFF
--- a/src/helpers/assets-manifest.js
+++ b/src/helpers/assets-manifest.js
@@ -1,18 +1,19 @@
 'use strict'
 
-const { execSync } = require('child_process')
-const fs = require('fs')
 const logger = require('@antora/logger')('assets-manifest-helper')
 
 module.exports = (assetPath) => {
-  let manifestPath
-  let manifest
-  try {
-    manifestPath = execSync('find ./build/site -name assets-manifest.json').toString().trim()
-    manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'))
-  } catch (err) {
-    logger.error(err)
+  const manifest = global.assetsManifest
+  if (!manifest) {
+    logger.error(
+      `
+      Assets manifest not found in global context.
+      The .js and .css files from the UI bundle will not be linked properly in the HTML.
+      Ensure assets-manifest.json from the UI bundle is parsed and added 
+      to global.assetsManifest after uiLoader is complete.
+      `
+    )
+    return assetPath
   }
-  if (manifest) return manifest[assetPath]
-  return assetPath
+  return manifest[assetPath]
 }


### PR DESCRIPTION
Relies on an Antora extension to set the assets-manifest object on the node global context