### PR TITLE
Wider versions dropdown

### DIFF
--- a/src/partials/page-versions.hbs
+++ b/src/partials/page-versions.hbs
@@ -4,7 +4,7 @@
     Version: <span class="font-bold ml-1">{{@root.page.componentVersion.displayVersion}}{{#if (eq @root.page.component.latest.version @root.page.componentVersion.version)}} (Latest){{/if}}</span>
     <i class="material-icons text-lg color-primary motion-safe:transition-transform motion-safe:duration-300 motion-safe:ease-in-out ml-[0.15em] group-[.active]:rotate-180">expand_more</i>
   </button>
-  <ul class="dropdown-content py-2 bg-body border rounded w-32 z-40" role="menu" aria-orientation="vertical" aria-labelledby="page-version-dropdown">
+  <ul class="dropdown-content py-2 bg-body border rounded w-64 z-40" role="menu" aria-orientation="vertical" aria-labelledby="page-version-dropdown">
     {{#each this}}
     <li>
       <a 


### PR DESCRIPTION
Before
<img width="206" alt="Screenshot 2024-07-26 at 11 52 58 AM" src="https://github.com/user-attachments/assets/42dce3c3-819f-4641-8a88-b5b3ab52d8ae">


After
<img width="267" alt="Screenshot 2024-07-26 at 11 53 59 AM" src="https://github.com/user-attachments/assets/1747bd31-0140-490b-b688-986a85a36636">

