### PR TITLE
Move feedback and pagination out of primary article tag

### DIFF
--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -14,8 +14,8 @@
   {{> tutorial-info}}
   {{/if}}
   {{{page.contents}}}
-  {{#unless (eq page.layout 'full')}}
-  {{> support-feedback }}
-  {{/unless}}
-  {{> pagination}}
 </article>
+{{#unless (eq page.layout 'full')}}
+{{> support-feedback }}
+{{/unless}}
+{{> pagination}}


### PR DESCRIPTION
This change moves the feedback section and pagination out of the primary `article` tag. 

This is to allow automated scraping to pick up only the page content itself without including the feedback markup/text on each page.