### PR TITLE
Move version picker to right of component home link

### DIFF
--- a/gulp.d/tasks/build-preview-pages.js
+++ b/gulp.d/tasks/build-preview-pages.js
@@ -11,7 +11,6 @@ const { Transform } = require('stream')
 const map = (transform = () => {}, flush = undefined) => new Transform({ objectMode: true, transform, flush })
 const vfs = require('vinyl-fs')
 const yaml = require('js-yaml')
-const { execSync } = require('child_process')
 
 const ASCIIDOC_ATTRIBUTES = { experimental: '', icons: 'font', sectanchors: '', 'source-highlighter': 'highlight.js' }
 
@@ -100,7 +99,8 @@ function registerPartials (src) {
 function registerHelpers (src, previewDest) {
   handlebars.registerHelper('resolvePage', resolvePage)
   handlebars.registerHelper('resolvePageURL', resolvePageURL)
-  handlebars.registerHelper('assets-manifest', (assetPath) => assetsManifest(assetPath, previewDest))
+  // Since we are not creating an assets-manifest.json file in the preview build, we need to mock the helper.
+  handlebars.registerHelper('assets-manifest', (assetPath) => assetPath)
   return vfs.src('helpers/*.js', { base: src, cwd: src }).pipe(
     map((file, enc, next) => {
       if (!(file.stem === 'assets-manifest')) {
@@ -126,12 +126,6 @@ function compileLayouts (src) {
       }
     )
   )
-}
-
-function assetsManifest (assetPath, previewDest) {
-  const manifestPath = execSync(`find ${previewDest} -name assets-manifest.json`).toString().trim()
-  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'))
-  return manifest[assetPath]
 }
 
 function copyImages (src, dest) {

--- a/gulp.d/tasks/build.js
+++ b/gulp.d/tasks/build.js
@@ -11,6 +11,7 @@ const ospath = require('path')
 const path = ospath.posix
 const postcss = require('gulp-postcss')
 const postcssCalc = require('postcss-calc')
+const gulpif = require('gulp-if')
 const postcssAdvancedVars = require('postcss-advanced-variables')
 const postcssImport = require('postcss-import')
 const tailwindcss = require('tailwindcss')
@@ -74,24 +75,24 @@ module.exports = (src, dest, preview) => () => {
       .pipe(uglify({ output: { comments: /^! / } }))
       // NOTE concat already uses stat from newest combined file
       .pipe(concat('js/site.js'))
-      .pipe(hash({ template: '<%= name %>-<%= hash %><%= ext %>' }))
+      .pipe(gulpif(!preview, hash({ template: '<%= name %>-<%= hash %><%= ext %>' })))
       .pipe(vfs.dest(dest))
-      .pipe(hash.manifest('assets-manifest.json', { append: true }))
+      .pipe(gulpif(!preview, hash.manifest('assets-manifest.json', { append: true })))
       .pipe(vfs.dest(dest)),
     vfs
       .src('js/vendor/*([^.])?(.bundle).js', { ...opts, read: false })
       .pipe(bundle(opts))
       .pipe(uglify({ output: { comments: /^! / } }))
-      .pipe(hash({ template: '<%= name %>-<%= hash %><%= ext %>' }))
+      .pipe(gulpif(!preview, hash({ template: '<%= name %>-<%= hash %><%= ext %>' })))
       .pipe(vfs.dest(dest))
-      .pipe(hash.manifest('assets-manifest.json', { append: true }))
+      .pipe(gulpif(!preview, hash.manifest('assets-manifest.json', { append: true })))
       .pipe(vfs.dest(dest)),
     vfs
       .src('js/vendor/*.min.js', opts)
       .pipe(map((file, enc, next) => next(null, Object.assign(file, { extname: '' }, { extname: '.js' }))))
-      .pipe(hash({ template: '<%= name %>-<%= hash %><%= ext %>' }))
+      .pipe(gulpif(!preview, hash({ template: '<%= name %>-<%= hash %><%= ext %>' })))
       .pipe(vfs.dest(dest))
-      .pipe(hash.manifest('assets-manifest.json', { append: true }))
+      .pipe(gulpif(!preview, hash.manifest('assets-manifest.json', { append: true })))
       .pipe(vfs.dest(dest)),
     // NOTE use the next line to bundle a JavaScript library that cannot be browserified, like jQuery
     //vfs.src(require.resolve('<package-name-or-require-path>'), opts).pipe(concat('js/vendor/<library-name>.js')),
@@ -99,9 +100,9 @@ module.exports = (src, dest, preview) => () => {
     vfs
       .src(['css/site.css', 'css/vendor/*.css'], { ...opts, sourcemaps })
       .pipe(postcss((file) => ({ plugins: postcssPlugins, options: { file } })))
-      .pipe(hash({ template: '<%= name %>-<%= hash %><%= ext %>' }))
+      .pipe(gulpif(!preview, hash({ template: '<%= name %>-<%= hash %><%= ext %>' })))
       .pipe(vfs.dest(dest))
-      .pipe(hash.manifest('assets-manifest.json', { append: true }))
+      .pipe(gulpif(!preview, hash.manifest('assets-manifest.json', { append: true })))
       .pipe(vfs.dest(dest)),
     vfs.src('font/*.{ttf,woff*(2)}', opts),
     vfs.src('img/**/*.{gif,ico,jpg,png,svg}', opts).pipe(

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "gulp-connect": "~5.7",
         "gulp-eslint": "~6.0",
         "gulp-hash": "^4.2.2",
+        "gulp-if": "^3.0.0",
         "gulp-imagemin": "~6.2",
         "gulp-postcss": "~9.0",
         "gulp-uglify": "~3.0",
@@ -5791,6 +5792,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/fork-stream": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/fork-stream/-/fork-stream-0.0.4.tgz",
+      "integrity": "sha512-Pqq5NnT78ehvUnAk/We/Jr22vSvanRlFTpAmQ88xBY/M1TlHe+P0ILuEyXS595ysdGfaj22634LBkGMA2GTcpA==",
+      "dev": true
+    },
     "node_modules/fraction.js": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
@@ -6407,6 +6414,27 @@
         "vinyl": "^2.1.0"
       }
     },
+    "node_modules/gulp-if": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-3.0.0.tgz",
+      "integrity": "sha512-fCUEngzNiEZEK2YuPm+sdMpO6ukb8+/qzbGfJBXyNOXz85bCG7yBI+pPSl+N90d7gnLvMsarthsAImx0qy7BAw==",
+      "dev": true,
+      "dependencies": {
+        "gulp-match": "^1.1.0",
+        "ternary-stream": "^3.0.0",
+        "through2": "^3.0.1"
+      }
+    },
+    "node_modules/gulp-if/node_modules/through2": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "2 || 3"
+      }
+    },
     "node_modules/gulp-imagemin": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/gulp-imagemin/-/gulp-imagemin-6.2.0.tgz",
@@ -6437,6 +6465,15 @@
         "gulp": {
           "optional": true
         }
+      }
+    },
+    "node_modules/gulp-match": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.1.0.tgz",
+      "integrity": "sha512-DlyVxa1Gj24DitY2OjEsS+X6tDpretuxD6wTfhXE/Rw2hweqc1f6D/XtsJmoiCwLWfXgR87W9ozEityPCVzGtQ==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^3.0.3"
       }
     },
     "node_modules/gulp-postcss": {
@@ -14411,9 +14448,9 @@
       }
     },
     "node_modules/stream-shift": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
       "dev": true
     },
     "node_modules/stream-splicer": {
@@ -15152,6 +15189,54 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/ternary-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-3.0.0.tgz",
+      "integrity": "sha512-oIzdi+UL/JdktkT+7KU5tSIQjj8pbShj3OASuvDEhm0NT5lppsm7aXWAmAq4/QMaBIyfuEcNLbAQA+HpaISobQ==",
+      "dev": true,
+      "dependencies": {
+        "duplexify": "^4.1.1",
+        "fork-stream": "^0.0.4",
+        "merge-stream": "^2.0.0",
+        "through2": "^3.0.1"
+      }
+    },
+    "node_modules/ternary-stream/node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
+    "node_modules/ternary-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/ternary-stream/node_modules/through2": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "2 || 3"
       }
     },
     "node_modules/text-table": {
@@ -21171,6 +21256,12 @@
         "for-in": "^1.0.1"
       }
     },
+    "fork-stream": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/fork-stream/-/fork-stream-0.0.4.tgz",
+      "integrity": "sha512-Pqq5NnT78ehvUnAk/We/Jr22vSvanRlFTpAmQ88xBY/M1TlHe+P0ILuEyXS595ysdGfaj22634LBkGMA2GTcpA==",
+      "dev": true
+    },
     "fraction.js": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
@@ -21690,6 +21781,29 @@
         "vinyl": "^2.1.0"
       }
     },
+    "gulp-if": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-3.0.0.tgz",
+      "integrity": "sha512-fCUEngzNiEZEK2YuPm+sdMpO6ukb8+/qzbGfJBXyNOXz85bCG7yBI+pPSl+N90d7gnLvMsarthsAImx0qy7BAw==",
+      "dev": true,
+      "requires": {
+        "gulp-match": "^1.1.0",
+        "ternary-stream": "^3.0.0",
+        "through2": "^3.0.1"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+          "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.4",
+            "readable-stream": "2 || 3"
+          }
+        }
+      }
+    },
     "gulp-imagemin": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/gulp-imagemin/-/gulp-imagemin-6.2.0.tgz",
@@ -21707,6 +21821,15 @@
         "plur": "^3.0.1",
         "pretty-bytes": "^5.3.0",
         "through2-concurrent": "^2.0.0"
+      }
+    },
+    "gulp-match": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.1.0.tgz",
+      "integrity": "sha512-DlyVxa1Gj24DitY2OjEsS+X6tDpretuxD6wTfhXE/Rw2hweqc1f6D/XtsJmoiCwLWfXgR87W9ozEityPCVzGtQ==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.3"
       }
     },
     "gulp-postcss": {
@@ -27857,9 +27980,9 @@
       }
     },
     "stream-shift": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
       "dev": true
     },
     "stream-splicer": {
@@ -28413,6 +28536,53 @@
       "requires": {
         "temp-dir": "^1.0.0",
         "uuid": "^3.0.1"
+      }
+    },
+    "ternary-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-3.0.0.tgz",
+      "integrity": "sha512-oIzdi+UL/JdktkT+7KU5tSIQjj8pbShj3OASuvDEhm0NT5lppsm7aXWAmAq4/QMaBIyfuEcNLbAQA+HpaISobQ==",
+      "dev": true,
+      "requires": {
+        "duplexify": "^4.1.1",
+        "fork-stream": "^0.0.4",
+        "merge-stream": "^2.0.0",
+        "through2": "^3.0.1"
+      },
+      "dependencies": {
+        "duplexify": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+          "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.4.1",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1",
+            "stream-shift": "^1.0.2"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "through2": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+          "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.4",
+            "readable-stream": "2 || 3"
+          }
+        }
       }
     },
     "text-table": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "gulp-connect": "~5.7",
     "gulp-eslint": "~6.0",
     "gulp-hash": "^4.2.2",
+    "gulp-if": "^3.0.0",
     "gulp-imagemin": "~6.2",
     "gulp-postcss": "~9.0",
     "gulp-uglify": "~3.0",

--- a/src/partials/breadcrumbs.hbs
+++ b/src/partials/breadcrumbs.hbs
@@ -8,8 +8,8 @@
     {{/if}}
     {{/with}}
     {{#each page.breadcrumbs}}
-    {{#if (eq ./urlType 'internal')}}
-    {{#if (or (not ./url) (is-last this ../page.breadcrumbs))}}
+    {{#if (and ./url (eq ./urlType 'internal'))}}
+    {{#if (is-last this ../page.breadcrumbs)}}
     <li class="text-tertiary !m-0 !p-0">{{{./content}}}</li>
     {{else}}
     <li class="text-link !m-0 !p-0 after:content-['/'] last-of-type:after:content-none after:text-tertiary after:px-2">

--- a/src/partials/breadcrumbs.hbs
+++ b/src/partials/breadcrumbs.hbs
@@ -8,8 +8,8 @@
     {{/if}}
     {{/with}}
     {{#each page.breadcrumbs}}
-    {{#if (and ./url (eq ./urlType 'internal'))}}
-    {{#if (is-last this ../page.breadcrumbs)}}
+    {{#if (eq ./urlType 'internal')}}
+    {{#if (or (not ./url) (is-last this ../page.breadcrumbs))}}
     <li class="text-tertiary !m-0 !p-0">{{{./content}}}</li>
     {{else}}
     <li class="text-link !m-0 !p-0 after:content-['/'] last-of-type:after:content-none after:text-tertiary after:px-2">

--- a/src/partials/nav.hbs
+++ b/src/partials/nav.hbs
@@ -6,10 +6,12 @@
   {{~/if}}
   id="side-nav" 
   class="h-full bg-level1 overflow-y-scroll flex flex-col w-[18.5rem] px-2 pt-2">
-    {{> page-versions page=../page}}
-    {{#with @root.page.componentVersion}}
-    <a class="p-2 mb-1 text-h4 hover:bg-level2 rounded transition-colors !no-underline" href="{{{relativize ./url}}}">{{./title}}</a>
-    {{/with}}
+    <div class="flex items-start gap-1 mb-1 ">
+      {{#with @root.page.componentVersion}}
+      <a class="flex flex-grow py-1 px-2 text-h4 hover:bg-level2 rounded transition-colors !no-underline" href="{{{relativize ./url}}}">{{./title}}</a>
+      {{/with}}
+      {{> page-versions page=../page}}
+    </div>
     {{> nav-tree navigation=this}}
     {{> nav-secondary}}
 </nav>

--- a/src/partials/page-versions.hbs
+++ b/src/partials/page-versions.hbs
@@ -1,7 +1,7 @@
 {{#with page.versions}}
 <div class="dropdown ml-auto">
   <button id="page-version-dropdown" title="Show other versions of page" class="group dropdown-trigger btn btn-soft btn-primary btn-small" aria-haspopup="true" aria-expanded="false">
-    <span class="font-bold ml-1">{{@root.page.componentVersion.displayVersion}}{{#if (eq @root.page.component.latest.version @root.page.componentVersion.version)}} (Latest){{/if}}</span>
+    <span class="font-bold ml-1 text-xs">{{@root.page.componentVersion.displayVersion}}</span>
     <i class="material-icons text-lg color-primary motion-safe:transition-transform motion-safe:duration-300 motion-safe:ease-in-out ml-[0.15em] group-[.active]:rotate-180">expand_more</i>
   </button>
   <ul class="dropdown-content py-2 bg-body border rounded w-48 z-40" role="menu" aria-orientation="vertical" aria-labelledby="page-version-dropdown">

--- a/src/partials/page-versions.hbs
+++ b/src/partials/page-versions.hbs
@@ -1,10 +1,10 @@
 {{#with page.versions}}
-<div class="dropdown my-2">
+<div class="dropdown ml-auto">
   <button id="page-version-dropdown" title="Show other versions of page" class="group dropdown-trigger btn btn-soft btn-primary btn-small" aria-haspopup="true" aria-expanded="false">
-    Version: <span class="font-bold ml-1">{{@root.page.componentVersion.displayVersion}}{{#if (eq @root.page.component.latest.version @root.page.componentVersion.version)}} (Latest){{/if}}</span>
+    <span class="font-bold ml-1">{{@root.page.componentVersion.displayVersion}}{{#if (eq @root.page.component.latest.version @root.page.componentVersion.version)}} (Latest){{/if}}</span>
     <i class="material-icons text-lg color-primary motion-safe:transition-transform motion-safe:duration-300 motion-safe:ease-in-out ml-[0.15em] group-[.active]:rotate-180">expand_more</i>
   </button>
-  <ul class="dropdown-content py-2 bg-body border rounded w-32 z-40" role="menu" aria-orientation="vertical" aria-labelledby="page-version-dropdown">
+  <ul class="dropdown-content py-2 bg-body border rounded w-48 z-40" role="menu" aria-orientation="vertical" aria-labelledby="page-version-dropdown">
     {{#each this}}
     <li>
       <a 


### PR DESCRIPTION
### A few things:
* Move the version picker to the right of the component title link (screenshots below)
* I noticed the hashed asset files seem to randomly break the dev preview using `gulp preview`. I changed the build so it doesn't hash the files when running that, it's not necessary there anyway.

<img width="354" alt="Screenshot 2024-08-26 at 2 41 55 PM" src="https://github.com/user-attachments/assets/7f7d6198-ba1b-48e1-b612-2823ec139364">
<img width="373" alt="Screenshot 2024-08-26 at 2 42 35 PM" src="https://github.com/user-attachments/assets/e5d8eab6-90bc-40f3-bc62-580d6425c6d5">
<img width="378" alt="Screenshot 2024-08-26 at 2 42 15 PM" src="https://github.com/user-attachments/assets/fd917e4c-b1d3-46aa-9faf-4c2b9a270829">


### Testing
This is a little hard to test because the Antora site build for this repo does not include any of the content repos that have versions. We won't be able to see this update until we make the full site preview build when making a PR to update the UI bundle. To test my changes here I ran a local build with a few content sources that have versions and a local UI bundle of these changes. 
