### PR TITLE
DOC-4329: Add Ketch smart tag

### DIFF
--- a/src/partials/head-prelude.hbs
+++ b/src/partials/head-prelude.hbs
@@ -9,3 +9,6 @@
     })(window,document,'script','dataLayer','{{this}}');</script>
     <!-- End Google Tag Manager -->
     {{/with}}
+    {{#with site.keys.ketchSmartTagUrl}}
+    <script>!function(){window.semaphore=window.semaphore||[],window.ketch=function(){window.semaphore.push(arguments)};var e=document.createElement("script");e.type="text/javascript",e.src="{{this}}",e.defer=e.async=!0,document.getElementsByTagName("head")[0].appendChild(e)}();</script>
+    {{/with}}


### PR DESCRIPTION
Jira: [DOC-4329](https://datastax.jira.com/browse/DOC-4329)

Adds the [Ketch smart tag](https://www.ketch.com/how-to-deploy-the-ketch-smart-tag) script to `head-prelude.hbs`. Just like other scripts of this nature, I've configured the UI to only add the script if a specific key is present in the playbook (see https://github.com/riptano/datastax-docs-site/pull/233).

[DOC-4329]: https://datastax.jira.com/browse/DOC-4329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ