### PR TITLE
Replace copyright year with dynamic helper

### DIFF
--- a/src/partials/footer.hbs
+++ b/src/partials/footer.hbs
@@ -11,7 +11,7 @@
     </a>
     <p class="!m-0">
       <span>©</span>
-      <span id="copyrightdate">2025</span>
+      <span id="copyrightdate">{{year}}</span>
       <span>DataStax |
         <a
           href="https://www.datastax.com/legal/datastax-website-privacy-policy"

--- a/src/partials/footer.hbs
+++ b/src/partials/footer.hbs
@@ -11,7 +11,7 @@
     </a>
     <p class="!m-0">
       <span>©</span>
-      <span id="copyrightdate">2024</span>
+      <span id="copyrightdate">2025</span>
       <span>DataStax |
         <a
           href="https://www.datastax.com/legal/datastax-website-privacy-policy"


### PR DESCRIPTION
Jira: [DOC-4861](https://datastax.jira.com/browse/DOC-4861)

Replaces the static copyright date in `footer.hbs` with the `{{year}}` helper to dynamically retrieve the current year at site build time.

[DOC-4861]: https://datastax.jira.com/browse/DOC-4861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ