### PR TITLE
Revert bundle asset hash changes

### DIFF
--- a/gulp.d/tasks/build.js
+++ b/gulp.d/tasks/build.js
@@ -77,7 +77,7 @@ module.exports = (src, dest, preview) => () => {
       .pipe(concat('js/site.js'))
       .pipe(gulpif(
         !preview,
-        hash({ template: '<%= name %>-<%= hash %><%= ext %>', hashLength: 10, version: 'prod-35' })))
+        hash({ template: '<%= name %>-<%= hash %><%= ext %>' })))
       .pipe(vfs.dest(dest))
       .pipe(gulpif(!preview, hash.manifest('assets-manifest.json', { append: true })))
       .pipe(vfs.dest(dest)),
@@ -89,7 +89,7 @@ module.exports = (src, dest, preview) => () => {
         ? through() : uglify({ output: { comments: /^! / } }))
       .pipe(gulpif(
         !preview,
-        hash({ template: '<%= name %>-<%= hash %><%= ext %>', hashLength: 10, version: 'prod-35' })))
+        hash({ template: '<%= name %>-<%= hash %><%= ext %>' })))
       .pipe(vfs.dest(dest))
       .pipe(gulpif(!preview, hash.manifest('assets-manifest.json', { append: true })))
       .pipe(vfs.dest(dest)),
@@ -98,7 +98,7 @@ module.exports = (src, dest, preview) => () => {
       .pipe(map((file, enc, next) => next(null, Object.assign(file, { extname: '' }, { extname: '.js' }))))
       .pipe(gulpif(
         !preview,
-        hash({ template: '<%= name %>-<%= hash %><%= ext %>', hashLength: 10, version: 'prod-35' })))
+        hash({ template: '<%= name %>-<%= hash %><%= ext %>' })))
       .pipe(vfs.dest(dest))
       .pipe(gulpif(!preview, hash.manifest('assets-manifest.json', { append: true })))
       .pipe(vfs.dest(dest)),
@@ -110,7 +110,7 @@ module.exports = (src, dest, preview) => () => {
       .pipe(postcss((file) => ({ plugins: postcssPlugins, options: { file } })))
       .pipe(gulpif(
         !preview,
-        hash({ template: '<%= name %>-<%= hash %><%= ext %>', hashLength: 10, version: 'prod-35' })))
+        hash({ template: '<%= name %>-<%= hash %><%= ext %>' })))
       .pipe(vfs.dest(dest))
       .pipe(gulpif(!preview, hash.manifest('assets-manifest.json', { append: true })))
       .pipe(vfs.dest(dest)),

--- a/src/js/vendor/floatingui.bundle.js
+++ b/src/js/vendor/floatingui.bundle.js
@@ -23,7 +23,7 @@
 ;(function () {
   'use strict'
 
-  const { computePosition, autoPlacement, shift } = require('@floating-ui/dom')
+  const { computePosition, autoPlacement, shift } = require('@floating-ui/dom/dist/floating-ui.dom.umd.min.js')
   const isTouchDevice = window.matchMedia('(pointer: coarse)').matches
 
   const hideAllDropdowns = () => {


### PR DESCRIPTION
### Previously
We wanted to force a re-upload of all asciidoc pages to prod, so we temporarily increased the asset manifest filename size by 2 more characters. This slightly increased the size of each built page to trigger the re-upload.

### This PR
Reverts the file name size change in the UI bundle build

### Going forward
We should create action to detect any changes to the UI bundle and force all pages to be rebuilt. This will solve the issue of some pages being rebuilt with a new UI and some not, resulting in the unbuilt pages trying to import incorrect asset files.