### PR TITLE
Bump trigger-workflow-and-wait to v1.6.5

### DIFF
--- a/.github/workflows/dispatch-deploy-draft.yml
+++ b/.github/workflows/dispatch-deploy-draft.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Dispatch Antora Build and Deploy
-        uses: convictional/trigger-workflow-and-wait@v1.6.1
+        uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
           owner: riptano
           repo: datastax-docs-site


### PR DESCRIPTION
## Summary
- Bump `convictional/trigger-workflow-and-wait` from v1.6.1 to v1.6.5 in `dispatch-deploy-draft.yml` to fix deprecated `set-output` warnings